### PR TITLE
use jsonc-parser to parse ts/jsconfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const parser = require("jsonc-parser");
 
 const HAS_EXT_REGEX = /\.[a-z]+$/;
 const JS_EXT_REGEX = /\.(ts|tsx|js|jsx|json)$/;
@@ -51,14 +52,14 @@ function getBaseUrl(baseDir) {
   let url = "";
 
   if (fs.existsSync(path.join(baseDir, "tsconfig.json"))) {
-    const tsconfig = JSON.parse(
-      fs.readFileSync(path.join(baseDir, "tsconfig.json"))
+    const tsconfig = parser.parse(
+      fs.readFileSync(path.join(baseDir, "tsconfig.json")).toString()
     );
     if (has(tsconfig, "compilerOptions.baseUrl")) {
       url = tsconfig.compilerOptions.baseUrl;
     }
   } else if (fs.existsSync(path.join(baseDir, "jsconfig.json"))) {
-    const jsconfig = JSON.parse(
+    const jsconfig = parser.parse(
       fs.readFileSync(path.join(baseDir, "jsconfig.json"))
     );
     if (has(jsconfig, "compilerOptions.baseUrl")) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,28 @@
 {
     "name": "eslint-plugin-absolute-imports-only",
     "version": "1.0.1",
-    "lockfileVersion": 1
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "eslint-plugin-absolute-imports-only",
+            "version": "1.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "jsonc-parser": "^3.2.0"
+            }
+        },
+        "node_modules/jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+        }
+    },
+    "dependencies": {
+        "jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
     "name": "eslint-plugin-absolute-imports-only",
     "version": "1.0.1",
     "main": "index.js",
-    "dependencies": {},
+    "dependencies": {
+        "jsonc-parser": "^3.2.0"
+    },
     "description": "Eslint rule enforcing absolute imports",
     "license": "MIT",
     "author": {
@@ -10,9 +12,16 @@
         "name": "Thao Tang",
         "url": "https://fr0stf0x.vercel.app"
     },
-    "categories": ["Linters"],
+    "categories": [
+        "Linters"
+    ],
     "repository": {
         "url": "https://www.github.com/fr0stf0x/eslint-plugin-absolute-imports"
     },
-    "keywords": ["eslint", "imports", "eslint-plugin", "absolute-imports"]
+    "keywords": [
+        "eslint",
+        "imports",
+        "eslint-plugin",
+        "absolute-imports"
+    ]
 }


### PR DESCRIPTION
Currently the plugin fails on tsconfig files with trailing commas and comments, while this is officially allowed by the TypeScript compiler. This MR changes the plugin to use [`jsonc-parser`](https://github.com/microsoft/node-jsonc-parser), which is what is used by TypeScript itself.